### PR TITLE
Use of append deprecated

### DIFF
--- a/TumorDecon/batch_correction.py
+++ b/TumorDecon/batch_correction.py
@@ -84,7 +84,7 @@ def remove_batch_effect(files_list, cell_type, address):
         assert(cell_type_data.shape[1] != 0), cell_type + " is not present in " + file_name
 
         temp_batch = pd.Series([i for _ in range(len(list(cell_type_data)))], index=list(cell_type_data))
-        batch = batch.append(temp_batch)
+        batch = batch._append(temp_batch)
         cell_type_data = cell_type_data.loc[~cell_type_data.index.duplicated(keep='first')]
         data_dict.append(cell_type_data)
     data_combined = pd.concat(data_dict, axis=1, sort=True)

--- a/TumorDecon/batch_correction.py
+++ b/TumorDecon/batch_correction.py
@@ -84,7 +84,10 @@ def remove_batch_effect(files_list, cell_type, address):
         assert(cell_type_data.shape[1] != 0), cell_type + " is not present in " + file_name
 
         temp_batch = pd.Series([i for _ in range(len(list(cell_type_data)))], index=list(cell_type_data))
-        batch = batch._append(temp_batch)
+        if batch.empty:
+            batch=temp_batch
+        else:           
+            batch = pd.concat([batch, temp_batch])
         cell_type_data = cell_type_data.loc[~cell_type_data.index.duplicated(keep='first')]
         data_dict.append(cell_type_data)
     data_combined = pd.concat(data_dict, axis=1, sort=True)


### PR DESCRIPTION
Use of .append is deprecated in pandas 2.0. Substituted with pd.concat after check that pd.series is not empty. 
For comparison:
https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.Series.html
https://pandas.pydata.org/docs/reference/api/pandas.Series.html
https://stackoverflow.com/questions/75956209/error-dataframe-object-has-no-attribute-append