### PR TITLE
Update SingScore.py, ssGSEA.py, and minimal.py

### DIFF
--- a/TumorDecon/GUI/minimal.py
+++ b/TumorDecon/GUI/minimal.py
@@ -208,7 +208,7 @@ def run_tumor_decon():
             scaling = 'minmax'
         new_text = "Ran "+m.get()+" with sig matrix "+s.get()+" and "+scaling+" normalization"
         status["text"] = new_text
-        solns = td.tumor_deconvolve(rna_df, method, patient_IDs='ALL', cell_signatures=sig_df, args={'scaling_axix':0, 'scaling':scaling})
+        solns = td.tumor_deconvolve(rna_df, method, patient_IDs='ALL', sig_matrix=sig_df, args={'scaling_axix':0, 'scaling':scaling})
 
     else: # ssgsea, singscore
         if u.get() == "ssGSEA paper gene set":

--- a/TumorDecon/SingScore.py
+++ b/TumorDecon/SingScore.py
@@ -23,7 +23,7 @@ def SingScore_main(rna_df, up_genes=None, down_genes=None, patient_IDs='ALL', ar
     from singscore import singscore
     import pandas as pd
     from .data_utils import read_ssGSEA_up_genes
-    from collections import Mapping
+    from collections.abc import Mapping
 
     # Select a patient / list of patients to solve for their cell type frequencies:
         # Patient_ID must be 'ALL' or an array of specific patient IDs.

--- a/TumorDecon/ssGSEA.py
+++ b/TumorDecon/ssGSEA.py
@@ -77,7 +77,7 @@ def ssGSEA_main(rna_df, up_genes=None, patient_IDs='ALL', args={}):
     """
     import pandas as pd
     import numpy as np
-    from collections import Mapping
+    from collections.abc import Mapping
     from .data_utils import read_ssGSEA_up_genes
 
     # Read in optional arguments, or set them as default


### PR DESCRIPTION
fix: update imports of the Mapping module
SingScore.py and ssGSEA.py use the Mapping module, which has been moved from collections to collections.abc in recent python versions

fix: adjust call of tumor_deconvolve
On line 211 of minimal.py, the signature matrix is passed in as "cell_signatures" instead of "sig_matrix", leading to an error. This has been changed so that the call functions properly.