### PR TITLE
Fix Python 3.10+ and pandas 2.0 compatibility issues

### DIFF
--- a/TumorDecon/batch_correction.py
+++ b/TumorDecon/batch_correction.py
@@ -75,7 +75,7 @@ def remove_batch_effect(files_list, cell_type, address):
     import pandas as pd
     from combat.pycombat import pycombat
 
-    batch = pd.Series()
+    batch_parts = []
     data_dict = []
     for (i, file_name) in enumerate(files_list):
         data = pd.read_csv(address+file_name, sep="\t", header=0)
@@ -83,10 +83,11 @@ def remove_batch_effect(files_list, cell_type, address):
         cell_type_data = data.loc[:, data.columns.str.contains(cell_type)]
         assert(cell_type_data.shape[1] != 0), cell_type + " is not present in " + file_name
 
-        temp_batch = pd.Series([i for _ in range(len(list(cell_type_data)))], index=list(cell_type_data))
-        batch = batch.append(temp_batch)
+        temp_batch = pd.Series([i] * cell_type_data.shape[1], index=cell_type_data.columns, dtype="int64")
+        batch_parts.append(temp_batch)
         cell_type_data = cell_type_data.loc[~cell_type_data.index.duplicated(keep='first')]
         data_dict.append(cell_type_data)
+    batch = pd.concat(batch_parts)    
     data_combined = pd.concat(data_dict, axis=1, sort=True)
     data_combined = data_combined.apply(lambda row: row.fillna(row.mean()), axis=1)
     data_combined.dropna(inplace=True)

--- a/TumorDecon/data_utils.py
+++ b/TumorDecon/data_utils.py
@@ -48,7 +48,7 @@ def read_rna_file(file_path, identifier='hugo', fetch_missing_hugo=False):
         else:
             raise ValueError("gene identifier must be set to 'hugo' or 'entrez'")
     else:
-        raise ReadError("Data Format not recognized")
+        raise ValueError("Data Format not recognized")
 
     # Drop duplicate genes:
     rna = rna.loc[~rna.index.duplicated(keep='first')] # argument keep = first, last, max, mean

--- a/TumorDecon/ssGSEA.py
+++ b/TumorDecon/ssGSEA.py
@@ -77,7 +77,7 @@ def ssGSEA_main(rna_df, up_genes=None, patient_IDs='ALL', args={}):
     """
     import pandas as pd
     import numpy as np
-    from collections import Mapping
+    from collections.abc import Mapping
     from .data_utils import read_ssGSEA_up_genes
 
     # Read in optional arguments, or set them as default


### PR DESCRIPTION
1. Fix Mapping import compatibility for Python 3.10+, this resolves the #6 
2. Fix SingScore crashes on pandas ≥ 2.0 caused by PySingscore calling DataFrame.append() (removed in pandas 2.0), while waiting for PySingscore to merge their fix.
3. Fix an undefined ReadError in data_util.py.